### PR TITLE
move current and concat view to shared org space

### DIFF
--- a/liiatools_pipeline/jobs/ssda903_org.py
+++ b/liiatools_pipeline/jobs/ssda903_org.py
@@ -9,7 +9,13 @@ from liiatools_pipeline.ops.ssda903_org import (
     ofsted_inspection,
     create_reports,
     create_org_session_folder,
+    move_current_and_concat_view,
 )
+
+
+@job
+def ssda903_move_current_and_concat():
+    move_current_and_concat_view()
 
 
 @job

--- a/liiatools_pipeline/ops/ssda903_la.py
+++ b/liiatools_pipeline/ops/ssda903_la.py
@@ -154,7 +154,7 @@ def move_current_view():
     ins={"current": In(DataframeArchive)},
 )
 def create_concatenated_view(current: DataframeArchive):
-    concat_folder = shared_folder().makedirs("concatenated", recreate=True)
+    concat_folder = shared_folder().makedirs("concatenated/ssda903", recreate=True)
     for la_code in authorities.codes:
         concat_data = current.current(la_code)
 

--- a/liiatools_pipeline/ops/ssda903_org.py
+++ b/liiatools_pipeline/ops/ssda903_org.py
@@ -24,6 +24,16 @@ from sufficiency_data_transform.all_dim_and_fact import (
 )
 
 
+@op()
+def move_current_and_concat_view():
+    current_folder = incoming_folder().opendir("current")
+    destination_folder = shared_folder()
+    pl.move_files_for_sharing(current_folder, destination_folder)
+
+    concat_folder = incoming_folder().opendir("concatenated/ssda903")
+    pl.move_files_for_sharing(concat_folder, destination_folder)
+
+
 @op(
     out={
         "session_folder": Out(FS),
@@ -35,7 +45,7 @@ def create_org_session_folder() -> FS:
     )
     session_folder = session_folder.opendir(SessionNamesOrg.INCOMING_FOLDER)
 
-    concat_folder = incoming_folder().opendir("concatenated")
+    concat_folder = incoming_folder().opendir("concatenated/ssda903")
     pl.move_files_for_sharing(concat_folder, session_folder)
 
     return session_folder

--- a/liiatools_pipeline/repository.py
+++ b/liiatools_pipeline/repository.py
@@ -6,7 +6,11 @@ from liiatools_pipeline.jobs.ssda903_la import (
     ssda903_move_current,
     ssda903_concatenate,
 )
-from liiatools_pipeline.jobs.ssda903_org import ssda903_sufficiency, ssda903_reports
+from liiatools_pipeline.jobs.ssda903_org import (
+    ssda903_move_current_and_concat,
+    ssda903_sufficiency,
+    ssda903_reports
+)
 from liiatools_pipeline.jobs.external_dataset import external_incoming
 from liiatools_pipeline.sensors.location_sensor import location_sensor
 from liiatools_pipeline.sensors.sufficiency_sensor import sufficiency_sensor
@@ -26,6 +30,7 @@ def sync():
         ssda903_clean,
         ssda903_move_current,
         ssda903_concatenate,
+        ssda903_move_current_and_concat,
         ssda903_reports,
         external_incoming,
         ssda903_sufficiency,


### PR DESCRIPTION
- Added a new job which moves current and concatenated files from the Shared LA bucket to the Shared Org bucket.
- Have also made sure concatenated folder is structured to include dataset folder e.g. concatenated/ssda903

