### PR TITLE
fix NaT error in fix_episodes; more robust sufficiency

### DIFF
--- a/liiatools/common/constants.py
+++ b/liiatools/common/constants.py
@@ -30,3 +30,8 @@ class SessionNamesOrg(StrEnum):
     """Enum for org session folders."""
 
     INCOMING_FOLDER = "incoming"
+
+class SessionNamesSufficiency(StrEnum):
+    """Enum for sufficiency session folders."""
+
+    INCOMING_FOLDER = "incoming"

--- a/liiatools/common/pipeline.py
+++ b/liiatools/common/pipeline.py
@@ -108,7 +108,7 @@ def move_files_for_sharing(
     source_fs: FS,
     destination_fs: FS,
     continue_on_error: bool = False,
-    required_table_id: str = None,
+    required_table_id: list = None,
 ):
     """
     Moves all files from a source filesystem to the shared folder. Allow movement of only specific files using the
@@ -124,7 +124,7 @@ def move_files_for_sharing(
                     copy_file(source_fs, file_path, destination_fs, dest_path)
                 else:
                     table_id = re.search(r"_([a-zA-Z0-9]*)\.", file_path)
-                    if table_id and table_id.group(1) == required_table_id:
+                    if table_id and table_id.group(1) in required_table_id:
                         dest_path = file_path.split("/")[-1]
                         copy_file(source_fs, file_path, destination_fs, dest_path)
             except Exception as e:

--- a/liiatools/ssda903_pipeline/fix_episodes.py
+++ b/liiatools/ssda903_pipeline/fix_episodes.py
@@ -76,11 +76,11 @@ def create_previous_and_next_episode(
 
 def format_datetime(dataframe: pd.DataFrame, date_columns: list) -> pd.DataFrame:
     """
-    Format date columns to datetime type
+    Format date columns to date type
 
     :param dataframe: Dataframe with SSDA903 Episodes data
     :param date_columns: List of columns containing dates
-    :return: Dataframe with date columns showing as datetime data type
+    :return: Dataframe with date columns showing as datetime.date data type
     """
     dataframe[date_columns] = dataframe[date_columns].apply(
         lambda row: pd.to_datetime(row, format="%Y-%m-%d", errors="raise").dt.date
@@ -325,13 +325,13 @@ def apply_stage1_rules(dataframe: pd.DataFrame) -> pd.DataFrame:
 
 
 def _overlaps_next_episode(row: pd.Series) -> bool:
-    if row["Has_next_episode"]:
+    if row["Has_next_episode"] and pd.notna(row["DEC"]):
         return (row.YEAR < row.YEAR_next) & (row.DEC > row.DECOM_next)
     return False
 
 
 def _has_x1_gap_before_next_episode(row: pd.Series) -> bool:
-    if row["Has_next_episode"]:
+    if row["Has_next_episode"] and pd.notna(row["DEC"]):
         return (
             (row.YEAR < row.YEAR_next) & (row.DEC < row.DECOM_next) & (row.REC == "X1")
         )

--- a/liiatools_pipeline/jobs/ssda903_org.py
+++ b/liiatools_pipeline/jobs/ssda903_org.py
@@ -6,4 +6,5 @@ from liiatools_pipeline.ops import ssda903_org as ssda903
 @job
 def ssda903_sufficiency():
     ssda903.output_lookup_tables()
-    ssda903.create_dim_fact_tables()
+    session_folder = ssda903.create_sufficiency_session_folder()
+    ssda903.create_dim_fact_tables(session_folder)

--- a/liiatools_pipeline/ops/ssda903_la.py
+++ b/liiatools_pipeline/ops/ssda903_la.py
@@ -27,7 +27,7 @@ def create_fix_episodes_session_folder() -> FS:
 
     concat_folder = shared_folder().opendir("concatenated/ssda903")
     pl.move_files_for_sharing(
-        concat_folder, session_folder, required_table_id="episodes"
+        concat_folder, session_folder, required_table_id=["episodes"]
     )
 
     return session_folder

--- a/liiatools_pipeline/ops/ssda903_org.py
+++ b/liiatools_pipeline/ops/ssda903_org.py
@@ -1,5 +1,9 @@
-from dagster import op
+from dagster import In, Out, op
+from fs.base import FS
+import re
 
+from liiatools.common import pipeline as pl
+from liiatools.common.constants import SessionNamesSufficiency
 from liiatools.common.data import DataContainer
 from liiatools.ssda903_pipeline.sufficiency_transform import (
     dict_to_dfs,
@@ -21,50 +25,88 @@ def output_lookup_tables():
     dim_dfs.export(shared_folder(), "", "csv")
 
 
-# This op should be ported to the external_dataset pipeline as it only needs to run when external inputs are changed
-@op
-def create_dim_fact_tables():
-    ext_folder = external_data_folder()
-    workspace = workspace_folder()
-    output_folder = shared_folder()
-
-    # Create empty dictionary to store tables
-    dim_tables = {}
-
-    # Create dimONSArea table
-    # Open external file
-    ONSArea = open_file(ext_folder, "ONS_Area.csv")
-    # Transform ONSArea table
-    ONSArea = ons_transform(ONSArea)
-    dim_tables["dimONSArea"] = ONSArea
-
-    # Create dimPostcode table
-    # Open external file
-    Postcode = open_file(ext_folder, "ONSPD_reduced_to_postcode_sector.csv")
-    # Transform Postcode table
-    Postcode = postcode_transform(Postcode)
-    dim_tables["dimPostcode"] = Postcode
-
-    # Create dimOfstedProvider and factOfstedInspection tables
-    # Open and transform files
-    OfstedProvider, factOfstedInspection = ofsted_transform(ext_folder, ONSArea)
-    dim_tables["dimOfstedProvider"] = OfstedProvider
-    dim_tables["factOfstedInspection"] = factOfstedInspection
-
-    # Create dimLookedAfterChild and factEpisode table
-    # Open ssda903 files
-    s903_folder = workspace.opendir("current/ssda903/PAN")
-    LookedAfterChild = open_file(s903_folder, "ssda903_header.csv")
-    UASC = open_file(s903_folder, "ssda903_uasc.csv")
-    Episode = open_file(s903_folder, "ssda903_episodes.csv")
-
-    # Transform tables
-    LookedAfterChild, factEpisode = ss903_transform(
-        LookedAfterChild, UASC, ONSArea, Episode, Postcode, OfstedProvider
+@op(
+    out={
+        "session_folder": Out(FS),
+    }
+)
+def create_sufficiency_session_folder() -> FS:
+    session_folder, session_id = pl.create_session_folder(
+        workspace_folder(), SessionNamesSufficiency
     )
-    dim_tables["dimLookedAfterChild"] = LookedAfterChild
-    dim_tables["factEpisode"] = factEpisode
+    session_folder = session_folder.opendir(SessionNamesSufficiency.INCOMING_FOLDER)
 
-    # Export tables
-    dim_tables = DataContainer(dim_tables)
-    dim_tables.export(output_folder, "", "csv")
+    reports_folder = workspace_folder().opendir("current/ssda903/SUFFICIENCY")
+    pl.move_files_for_sharing(
+        reports_folder, session_folder, required_table_id=["episodes", "header", "uasc"]
+    )
+
+    return session_folder
+
+
+@op(
+    ins={
+        "session_folder": In(FS),
+    },
+)
+def create_dim_fact_tables(
+    session_folder: FS,
+):
+    # Check that the files necessary for the job are in the folder
+    episodes = re.compile(r"episodes")
+    header = re.compile(r"header")
+    uasc = re.compile(r"uasc")
+    pattern_list = [episodes, header, uasc]
+    
+    files = session_folder.listdir("/")
+    
+    all_files_present = all(
+        any(pattern.search(filename) for filename in files)
+        for pattern in pattern_list
+    )
+
+    # Run the data transformation if all necessary files are present
+    if all_files_present:
+    
+        ext_folder = external_data_folder()
+        output_folder = shared_folder()
+
+        # Create empty dictionary to store tables
+        dim_tables = {}
+
+        # Create dimONSArea table
+        # Open external file
+        ONSArea = open_file(ext_folder, "ONS_Area.csv")
+        # Transform ONSArea table
+        ONSArea = ons_transform(ONSArea)
+        dim_tables["dimONSArea"] = ONSArea
+
+        # Create dimPostcode table
+        # Open external file
+        Postcode = open_file(ext_folder, "ONSPD_reduced_to_postcode_sector.csv")
+        # Transform Postcode table
+        Postcode = postcode_transform(Postcode)
+        dim_tables["dimPostcode"] = Postcode
+
+        # Create dimOfstedProvider and factOfstedInspection tables
+        # Open and transform files
+        OfstedProvider, factOfstedInspection = ofsted_transform(ext_folder, ONSArea)
+        dim_tables["dimOfstedProvider"] = OfstedProvider
+        dim_tables["factOfstedInspection"] = factOfstedInspection
+
+        # Create dimLookedAfterChild and factEpisode table
+        # Open ssda903 files
+        LookedAfterChild = open_file(session_folder, "ssda903_header.csv")
+        UASC = open_file(session_folder, "ssda903_uasc.csv")
+        Episode = open_file(session_folder, "ssda903_episodes.csv")
+
+        # Transform tables
+        LookedAfterChild, factEpisode = ss903_transform(
+            LookedAfterChild, UASC, ONSArea, Episode, Postcode, OfstedProvider
+        )
+        dim_tables["dimLookedAfterChild"] = LookedAfterChild
+        dim_tables["factEpisode"] = factEpisode
+
+        # Export tables
+        dim_tables = DataContainer(dim_tables)
+        dim_tables.export(output_folder, "", "csv")


### PR DESCRIPTION
Three main changes in this PR:
- [ ] fix_episodes NaT error issue resolved by preventing comparison between date fields when one may be null
- [ ] added sessions to the sufficiency job; mimics the fix_episodes session folder
- [ ] requirement for all three 903 files required for sufficiency job to be present in session folder at beginning of main sufficiency function; nothing will happen if they are not all present. To do this, I amended the required_table_id variable in pl.move_files_for_sharing to be a list instead of a str