### PR TITLE
adjust regex for capturing table id

### DIFF
--- a/liiatools/common/archive.py
+++ b/liiatools/common/archive.py
@@ -115,7 +115,7 @@ class DataframeArchive:
         Load a snapshot from the archive.
         """
         data = DataContainer()
-        table_id = re.search(r"_([a-zA-Z0-9]*)\.", snap_id)
+        table_id = re.search(r"\d{4}_([a-zA-Z0-9_]*)\.", snap_id)
 
         for table_spec in self.config.table_list:
             if table_id and table_id.group(1) == table_spec.id:


### PR DESCRIPTION
Adjusted the regex for capturing table_id from filenames. Now looks for 4 digits and and underscore to capture:
919_2017_prev_perm.csv

Previously it would match this as just _perm. resulting in a table_id of perm which doesn't match the expected prev_perm.
Now it will match 2017_prev_perm. resulting in a table_id of prev_perm.

Still works for original filenames e.g.:
919_2017_oc3.csv -> oc3
919_2017_header.csv -> header