### PR TITLE
separate move current and move concat

### DIFF
--- a/liiatools_pipeline/jobs/common_org.py
+++ b/liiatools_pipeline/jobs/common_org.py
@@ -4,7 +4,8 @@ from liiatools_pipeline.ops.common_org import (
     create_reports,
     create_org_session_folder,
     move_error_report,
-    move_current_and_concat_view,
+    move_current_view,
+    move_concat_view,
 )
 
 log = get_dagster_logger()
@@ -16,11 +17,16 @@ def move_error_reports():
 
 
 @job
-def move_current_and_concat():
-    move_current_and_concat_view()
+def move_current():
+    move_current_view()
 
 
-@job (
+@job
+def move_concat():
+    move_concat_view()
+
+
+@job(
     tags={"dagster/max_runtime": 1800}
 )
 def reports():

--- a/liiatools_pipeline/ops/common_org.py
+++ b/liiatools_pipeline/ops/common_org.py
@@ -17,6 +17,7 @@ from liiatools_pipeline.assets.common import (
 
 log = get_dagster_logger()
 
+
 @op()
 def move_error_report():
     source_folder = incoming_folder().opendir("logs")
@@ -26,7 +27,7 @@ def move_error_report():
 
 
 @op()
-def move_current_and_concat_view(config: CleanConfig):
+def move_current_view():
     current_folder = incoming_folder().opendir("current")
     destination_folder = shared_folder()
     
@@ -39,11 +40,19 @@ def move_current_and_concat_view(config: CleanConfig):
     log.info("Moving current files to destination...")
     pl.move_files_for_sharing(current_folder, destination_folder)
 
-    log.info("Moving concat files to destination...")
-    concat_folder = incoming_folder().opendir(f"concatenated/{config.dataset}")
 
+@op()
+def move_concat_view(config: CleanConfig):
+    concat_folder = incoming_folder().opendir(f"concatenated/{config.dataset}")
+    destination_folder = shared_folder()
+
+    existing_files = destination_folder.listdir("/")
+
+    authority_regex = "|".join(authorities.codes)
     concat_files_regex = f"({authority_regex})_{config.dataset}"
     pl.remove_files(concat_files_regex, existing_files, destination_folder)
+
+    log.info("Moving concat files to destination...")
     pl.move_files_for_sharing(concat_folder, destination_folder)
 
 

--- a/liiatools_pipeline/repository_org.py
+++ b/liiatools_pipeline/repository_org.py
@@ -3,7 +3,8 @@ from liiatools.common._fs_serializer import register
 
 from liiatools_pipeline.jobs.common_org import (
     move_error_reports,
-    move_current_and_concat,
+    move_current,
+    move_concat,
     reports,
 )
 from liiatools_pipeline.jobs.ssda903_org import ssda903_sufficiency
@@ -13,7 +14,8 @@ from liiatools_pipeline.sensors.location_schedule import (
 )
 from liiatools_pipeline.sensors.job_success_sensor import (
     move_error_reports_sensor,
-    move_current_and_concat_sensor,
+    move_current_sensor,
+    move_concat_sensor,
     sufficiency_sensor,
 )
 
@@ -30,7 +32,8 @@ def sync():
     """
     jobs = [
         move_error_reports,
-        move_current_and_concat,
+        move_current,
+        move_concat,
         reports,
         external_incoming,
         ssda903_sufficiency,
@@ -40,7 +43,8 @@ def sync():
     ]
     sensors = [
         move_error_reports_sensor,
-        move_current_and_concat_sensor,
+        move_current_sensor,
+        move_concat_sensor,
         sufficiency_sensor,
     ]
 


### PR DESCRIPTION
Separate the move_current_and_concat job into two jobs. This is because move_current is dataset agnostic (it tries to move all "current" files ssda903 and cin) so when the job was running in parallel we were getting errors as the same files were trying to be deleted and reuploaded at the same time