### PR TITLE
rename move_current functions

### DIFF
--- a/liiatools_pipeline/jobs/common_la.py
+++ b/liiatools_pipeline/jobs/common_la.py
@@ -5,6 +5,7 @@ from dagster import get_dagster_logger
 
 log = get_dagster_logger(__name__)
 
+
 @job
 def clean():
     log.info("Creating Session Folder...")
@@ -16,7 +17,7 @@ def clean():
 
 
 @job
-def move_current():
+def move_current_la():
     common_la.move_current_view()
 
 

--- a/liiatools_pipeline/jobs/common_org.py
+++ b/liiatools_pipeline/jobs/common_org.py
@@ -17,7 +17,7 @@ def move_error_reports():
 
 
 @job
-def move_current():
+def move_current_org():
     move_current_view()
 
 

--- a/liiatools_pipeline/repository_la.py
+++ b/liiatools_pipeline/repository_la.py
@@ -3,7 +3,7 @@ from liiatools.common._fs_serializer import register
 
 from liiatools_pipeline.jobs.common_la import (
     clean,
-    move_current,
+    move_current_la,
     concatenate,
 )
 from liiatools_pipeline.jobs.ssda903_la import ssda903_fix_episodes
@@ -29,7 +29,7 @@ def sync():
     """
     jobs = [
         clean,
-        move_current,
+        move_current_la,
         concatenate,
         ssda903_fix_episodes,
     ]

--- a/liiatools_pipeline/repository_org.py
+++ b/liiatools_pipeline/repository_org.py
@@ -3,7 +3,7 @@ from liiatools.common._fs_serializer import register
 
 from liiatools_pipeline.jobs.common_org import (
     move_error_reports,
-    move_current,
+    move_current_org,
     move_concat,
     reports,
 )
@@ -32,7 +32,7 @@ def sync():
     """
     jobs = [
         move_error_reports,
-        move_current,
+        move_current_org,
         move_concat,
         reports,
         external_incoming,

--- a/liiatools_pipeline/sensors/job_success_sensor.py
+++ b/liiatools_pipeline/sensors/job_success_sensor.py
@@ -8,11 +8,11 @@ from dagster import (
 )
 from decouple import config as env_config
 
-from liiatools_pipeline.jobs.common_la import clean, move_current, concatenate
+from liiatools_pipeline.jobs.common_la import clean, move_current_la, concatenate
 from liiatools_pipeline.jobs.ssda903_la import ssda903_fix_episodes
 from liiatools_pipeline.jobs.common_org import (
     move_error_reports,
-    move_current,
+    move_current_org,
     move_concat,
     reports,
 )
@@ -32,8 +32,8 @@ def find_previous_matching_dataset_run(run_records, dataset):
 
 
 @sensor(
-    job=move_current,
-    description="Runs move_current job once clean job is complete",
+    job=move_current_la,
+    description="Runs move_current_la job once clean job is complete",
     default_status=DefaultSensorStatus.RUNNING,
 )
 def move_current_sensor(context):
@@ -72,7 +72,7 @@ def concatenate_sensor(context):
 
     run_records = context.instance.get_run_records(
         filters=RunsFilter(
-            job_name=move_current.name,
+            job_name=move_current_la.name,
             statuses=[DagsterRunStatus.SUCCESS],
             tags={"dataset": allowed_datasets},
         ),
@@ -151,8 +151,8 @@ def move_error_reports_sensor(context):
 
 
 @sensor(
-    job=move_current,
-    description="Runs move_current job once reports job is complete",
+    job=move_current_org,
+    description="Runs move_current_org job once reports job is complete",
     default_status=DefaultSensorStatus.RUNNING,
 )
 def move_current_sensor(context):

--- a/liiatools_pipeline/sensors/location_schedule.py
+++ b/liiatools_pipeline/sensors/location_schedule.py
@@ -1,5 +1,4 @@
 from hashlib import sha1
-import sys
 
 import fs.errors
 from dagster import (


### PR DESCRIPTION
Rename dagster jobs to remove error due to ambiguity 