### PR TITLE
Allow list codes yml

### DIFF
--- a/liiatools/cin_census_pipeline/pipeline.py
+++ b/liiatools/cin_census_pipeline/pipeline.py
@@ -145,7 +145,9 @@ def create_current_view(archive: DataframeArchive, process_folder: FS) -> FS:
 
 def create_reports(current_folder: FS, process_folder: FS):
     export_folder = process_folder.makedirs("export", recreate=True)
-    aggregate = DataframeAggregator(current_folder, load_pipeline_config(), dataset="cin")
+    aggregate = DataframeAggregator(
+        current_folder, load_pipeline_config(), dataset="cin"
+    )
     aggregate_data = aggregate.current()
 
     for report in ["PAN"]:

--- a/liiatools/common/aggregate.py
+++ b/liiatools/common/aggregate.py
@@ -38,7 +38,7 @@ class DataframeAggregator:
         Load a file from the current directory.
         """
         data = DataContainer()
-        table_id = re.search(fr"{self.dataset}_([a-zA-Z0-9_]*)\.", file)
+        table_id = re.search(rf"{self.dataset}_([a-zA-Z0-9_]*)\.", file)
 
         for table_spec in self.config.table_list:
             if table_id and table_id.group(1) == table_spec.id:

--- a/liiatools/common/converters.py
+++ b/liiatools/common/converters.py
@@ -43,8 +43,8 @@ def to_category(value: str, column: Column):
     the config file should contain a dictionary for each category for this function to loop through
     return blank if no categories found
 
-    :param string: Some string to convert into a category value
-    :param categories: A list of dictionaries containing different category:value pairs
+    :param value: Some string to convert into a category value
+    :param column: A Column class containing different category:value pairs
     :return: Either a category value, "error" or blank string
     """
     match = column.match_category(str(value).strip())

--- a/liiatools/common/pipeline.py
+++ b/liiatools/common/pipeline.py
@@ -73,7 +73,9 @@ def create_session_folder(destination_fs: FS, session_names) -> Tuple[FS, str]:
             f"{ProcessNames.SESSIONS_FOLDER}/{session_id}"
         )
     except Exception as err:
-        logger.error(f"Can't create session folder {ProcessNames.SESSIONS_FOLDER} using {session_id}")
+        logger.error(
+            f"Can't create session folder {ProcessNames.SESSIONS_FOLDER} using {session_id}"
+        )
     for folder in session_names:
         logger.info(f"Creating session name folder: {folder}")
         session_folder.makedirs(folder)

--- a/liiatools/common/spec/__data_schema.py
+++ b/liiatools/common/spec/__data_schema.py
@@ -14,7 +14,7 @@ class Category(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     code: str
-    name: str = None
+    name: str | list = None
     cell_regex: Any
 
     __values: str = Field("")
@@ -24,10 +24,19 @@ class Category(BaseModel):
 
     def __contains__(self, item):
         values = {self.code.lower()}
-        if self.name:
-            values.add(self.name.lower())
 
-        is_numeric = self.code.isnumeric() or (self.name and self.name.isnumeric())
+        if isinstance(self.name, str):
+            values.add(self.name.lower())
+        elif isinstance(self.name, list):
+            values.update({name.lower() for name in self.name})
+
+        is_numeric = self.code.isnumeric() or (
+            isinstance(self.name, str) and self.name.isnumeric()
+        ) or (
+            isinstance(self.name, list) and any(
+                name.isnumeric() for name in self.name
+            )
+        )
 
         if item in values:
             return True
@@ -122,7 +131,7 @@ class Column(BaseModel):
 
         return re.compile(pattern, flags)
 
-    def match_category(self, value: str) -> Optional[Category]:
+    def match_category(self, value: str) -> Optional[str]:
         assert self.category, "Column is not a category"
 
         value = value.strip().lower()

--- a/liiatools/common/spec/__data_schema.py
+++ b/liiatools/common/spec/__data_schema.py
@@ -30,11 +30,12 @@ class Category(BaseModel):
         elif isinstance(self.name, list):
             values.update({name.lower() for name in self.name})
 
-        is_numeric = self.code.isnumeric() or (
-            isinstance(self.name, str) and self.name.isnumeric()
-        ) or (
-            isinstance(self.name, list) and any(
-                name.isnumeric() for name in self.name
+        is_numeric = (
+            self.code.isnumeric()
+            or (isinstance(self.name, str) and self.name.isnumeric())
+            or (
+                isinstance(self.name, list)
+                and any(name.isnumeric() for name in self.name)
             )
         )
 

--- a/liiatools/ssda903_pipeline/pipeline.py
+++ b/liiatools/ssda903_pipeline/pipeline.py
@@ -137,7 +137,9 @@ def create_current_view(archive: DataframeArchive, process_folder: FS) -> FS:
 
 def create_reports(current_folder: FS, process_folder: FS):
     export_folder = process_folder.makedirs("export", recreate=True)
-    aggregate = DataframeAggregator(current_folder, load_pipeline_config(), dataset="ssda903")
+    aggregate = DataframeAggregator(
+        current_folder, load_pipeline_config(), dataset="ssda903"
+    )
     aggregate_data = aggregate.current()
 
     for report in ["PAN", "SUFFICIENCY"]:

--- a/liiatools/tests/common/test_converters.py
+++ b/liiatools/tests/common/test_converters.py
@@ -56,10 +56,11 @@ def test_to_category():
 
     column = Column(
         canbeblank=False,
-        category=[{"code": "0", "name": "False"}, {"code": "1", "name": "True"}],
+        category=[{"code": "False", "name": ["F", "0"]}, {"code": "1", "name": "True"}],
     )
-    assert to_category(0, column) == "0"
-    assert to_category("false", column) == "0"
+    assert to_category(0, column) == "False"
+    assert to_category("false", column) == "False"
+    assert to_category("f", column) == "False"
     assert to_category(1.0, column) == "1"
     assert to_category("true", column) == "1"
     assert to_category("", column) == ""

--- a/liiatools_pipeline/jobs/common_org.py
+++ b/liiatools_pipeline/jobs/common_org.py
@@ -26,9 +26,7 @@ def move_concat():
     move_concat_view()
 
 
-@job(
-    tags={"dagster/max_runtime": 1800}
-)
+@job(tags={"dagster/max_runtime": 1800})
 def reports():
     log.info("Starting Reports run. Creating session folder...")
     session_folder = create_org_session_folder()

--- a/liiatools_pipeline/jobs/ssda903_la.py
+++ b/liiatools_pipeline/jobs/ssda903_la.py
@@ -5,6 +5,7 @@ from dagster import get_dagster_logger
 
 log = get_dagster_logger()
 
+
 @job
 def ssda903_fix_episodes():
     log.info("Fixing Episodes...")

--- a/liiatools_pipeline/jobs/ssda903_org.py
+++ b/liiatools_pipeline/jobs/ssda903_org.py
@@ -3,6 +3,7 @@ from liiatools_pipeline.ops import ssda903_org as ssda903
 
 log = get_dagster_logger()
 
+
 @job
 def ssda903_sufficiency():
     log.info("Creating lookup tables...")

--- a/liiatools_pipeline/ops/common_org.py
+++ b/liiatools_pipeline/ops/common_org.py
@@ -30,7 +30,7 @@ def move_error_report():
 def move_current_view_org():
     current_folder = incoming_folder().opendir("current")
     destination_folder = shared_folder()
-    
+
     existing_files = destination_folder.listdir("/")
 
     authority_regex = "|".join(authorities.codes)
@@ -92,7 +92,9 @@ def create_reports(
         f"current/{config.dataset}", recreate=True
     )
     log.info("Aggregating Data Frames...")
-    aggregate = DataframeAggregator(session_folder, pipeline_config(config), config.dataset)
+    aggregate = DataframeAggregator(
+        session_folder, pipeline_config(config), config.dataset
+    )
     aggregate_data = aggregate.current()
     log.debug(f"Using config: {config}")
     for report in pipeline_config(config).retention_period.keys():
@@ -117,5 +119,7 @@ def create_reports(
 
         existing_shared_files = shared_folder().listdir("/")
         log.info(f"Exporting report {report} to shared folder...")
-        pl.remove_files(f"{report}_{config.dataset}", existing_shared_files, shared_folder())
+        pl.remove_files(
+            f"{report}_{config.dataset}", existing_shared_files, shared_folder()
+        )
         report_data.export(shared_folder(), f"{report}_{config.dataset}_", "csv")

--- a/liiatools_pipeline/ops/ssda903_org.py
+++ b/liiatools_pipeline/ops/ssda903_org.py
@@ -57,17 +57,16 @@ def create_dim_fact_tables(
     header = re.compile(r"header")
     uasc = re.compile(r"uasc")
     pattern_list = [episodes, header, uasc]
-    
+
     files = session_folder.listdir("/")
-    
+
     all_files_present = all(
-        any(pattern.search(filename) for filename in files)
-        for pattern in pattern_list
+        any(pattern.search(filename) for filename in files) for pattern in pattern_list
     )
 
     # Run the data transformation if all necessary files are present
     if all_files_present:
-    
+
         ext_folder = external_data_folder()
         output_folder = shared_folder()
 

--- a/liiatools_pipeline/sensors/job_success_sensor.py
+++ b/liiatools_pipeline/sensors/job_success_sensor.py
@@ -151,7 +151,9 @@ def move_error_reports_sensor(context):
     )
 
     if run_records:  # Ensure there is at least one run record
-        context.log.info(f"Run records found for reports job in move error reports sensor")
+        context.log.info(
+            f"Run records found for reports job in move error reports sensor"
+        )
         latest_run_record = run_records[0]  # Get the most recent run record
         context.log.info(f"Run key: {latest_run_record.dagster_run.run_id}")
         yield RunRequest(

--- a/liiatools_pipeline/sensors/location_schedule.py
+++ b/liiatools_pipeline/sensors/location_schedule.py
@@ -7,7 +7,7 @@ from dagster import (
     schedule,
     RunsFilter,
     DagsterRunStatus,
-    DefaultScheduleStatus
+    DefaultScheduleStatus,
 )
 from fs import open_fs
 from fs.walk import Walker
@@ -215,7 +215,9 @@ def reports_schedule(context):
             context,
         )
 
-        context.log.info(f"Have we found a previous matching ID? {previous_matching_run_id}")
+        context.log.info(
+            f"Have we found a previous matching ID? {previous_matching_run_id}"
+        )
 
         clean_config = CleanConfig(
             dataset_folder=None,


### PR DESCRIPTION
In the schema.yml files this change now allows a list of items to be entered into the "name" section. 

In practice this means we can have a long list of multiple options for categorical questions, which is necessary for the annex_a update where we will be using a lookup table to create those lists