### PR TITLE
allow rows to be removed based on given values

### DIFF
--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -334,12 +334,21 @@ def conform_cell_types(event, preserve_value=False):
 @collectors.collector(
     check=collectors.block_check(events.StartRow), receive_stream=True
 )
-def collect_cell_values_for_row(row):
+def collect_cell_values_for_row(
+    row, remove_rows=False, table_name=None, header=None, value=None
+):
     """
     Collects the cell values for each row and set these as `column_spec` on the StartRow event.
 
+    Params:
+        * `row` - An events.StartRow event to process
+        * `remove_rows` - If True, rows where the header does not match the value will be removed
+        * `table_name` - The table to match
+        * `header` - The header to match
+        * `value` - The value to match
+
     Requires:
-        * `table_spec` on Cell events to idenfity this column as part of the table
+        * `table_spec` on Cell events to identify this column as part of the table
         * `header` on Cell events with the column key
         * `cell` on Cell events with the value
 
@@ -350,6 +359,11 @@ def collect_cell_values_for_row(row):
         * All the events
 
     """
+    if remove_rows:
+        assert (
+            table_name is not None and header is not None and value is not None
+        ), "If remove_rows is True, table_name, header and value must be set"
+
     # Read the row
     row = list(row)
 
@@ -359,13 +373,19 @@ def collect_cell_values_for_row(row):
 
     # Where we have identified the column, set values on the start row
     values = {}
+    r_ix = None
     for cell in row:
         schema: Column = getattr(cell, "column_spec", None)
         if schema:
             values[cell.header] = cell.cell
+            r_ix = cell.r_ix
+
+    if remove_rows and table_name == start_row.table_name:
+        if values[header] != value:
+            values = None
 
     # Yield events
-    yield start_row.from_event(start_row, row_values=values)
+    yield start_row.from_event(start_row, row_values=values, r_ix=r_ix)
     yield from row
     yield end_row
 
@@ -396,7 +416,14 @@ def collect_tables(stream):
     for event in stream:
         if isinstance(event, events.StartRow) and hasattr(event, "table_name"):
             table_data = dataset.setdefault(event.table_name, [])
-            table_data.append(event.row_values)
+            if event.row_values is not None:
+                table_data.append(event.row_values)
+            else:
+                yield EventErrors.add_to_event(
+                    event,
+                    type="InvalidMandatoryField",
+                    message=f"Row {event.r_ix} removed due to invalid mandatory field",
+                )
 
         yield event
 


### PR DESCRIPTION
Allow rows of data to be removed from specific datasets given a table_name, header and value.
- The table_name identifies which tables to apply this to
- The header identifies which column to check against
- The value is the value that needs to match the cell value for that row to be kept
Currently only works with one table, header and value combination per pipeline

Outputs a new error code to identify which row of the original data has been removed