### PR TITLE
image build pulls latest git packages

### DIFF
--- a/.github/workflows/base_build.yml
+++ b/.github/workflows/base_build.yml
@@ -29,6 +29,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies (pull latest Git-based packages)
+        run: |
+          poetry lock --no-update
+          poetry install
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2072,8 +2072,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/SocialFinanceDigitalLabs/liia-tools-pipeline-config.git"
-reference = "HEAD"
-resolved_reference = "7a600c6c9feee7957540e5d297b91b97500f45fc"
+reference = "main"
+resolved_reference = "963fdd9045b2134e12f0f924a3fd0951307fc0e9"
 
 [[package]]
 name = "lxml"
@@ -3142,6 +3142,7 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
+    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},
@@ -5238,4 +5239,4 @@ s3 = ["fs-s3fs"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "2198db9e2829a70600e037499b2338e04f8cf3e292f76645cb15b1763bd3cb92"
+content-hash = "e0ca011854a7b748a2eb96f9c52c3349dae2521828f03af5df558c4d467784f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dagster-postgres = "^0.22.11"
 alembic = "^1.13.1"
 python-dateutil = "^2.9.0.post0"
 chardet = "^5.2.0"
-liia-tools-pipeline-config = {git = "https://github.com/SocialFinanceDigitalLabs/liia-tools-pipeline-config.git"}
+liia-tools-pipeline-config = {git = "https://github.com/SocialFinanceDigitalLabs/liia-tools-pipeline-config.git", rev = "main"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.1"


### PR DESCRIPTION
Theoretically, specifying `rev = "main"` and then installing poetry in the image build should mean that the latest version of the package is pulled on each build.

Potential to cause issues if, down the line, the python requirement for the project changes.