### PR TITLE
only process files with la signatures

### DIFF
--- a/liiatools_pipeline/ops/common_la.py
+++ b/liiatools_pipeline/ops/common_la.py
@@ -95,6 +95,11 @@ def process_files(
         for file in current_files:
             current.fs.remove(f"{current_path}/{file}")
 
+    la_name = authorities.get_by_code(config.input_la_code)
+    la_signed = pipeline_config(config).la_signed[la_name]["PAN"]
+    if la_signed == "No":
+        return
+
     for file_locator in incoming_files:
         log.info(f"Processing file {file_locator.name}")
         uuid = file_locator.meta["uuid"]


### PR DESCRIPTION
Check the LA signature of PAN before processing any files from a given LA. This occurs after file removal to ensure that a given LAs files can still be removed using the existing pipeline process. This does mean the files will still be moved to the sessions/session_id/incoming folder but these files are deleted periodically from this secure location so I believe security risks are minimal