### PR TITLE
add codeowners file to restict PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This line sets default owners for ALL files in the repo, in this case the users of data-platform
+*       @SocialFinanceDigitalLabs/data-platform


### PR DESCRIPTION
Have added a codeowners file so someone from the SF data-platform team needs to approve a PR before it can be merged into main. This will allow external users to contribute to this repository whilst SF maintains protection of the main branch and therefore security of the codebase