### PR TITLE
turns all blanks pd.NA, np.nan, None, into empty string during to_integer

### DIFF
--- a/liiatools/common/_transform_functions.py
+++ b/liiatools/common/_transform_functions.py
@@ -55,10 +55,15 @@ def add_month(row: pd.Series, column_config: ColumnConfig, metadata: Metadata) -
 def to_integer(
     row: pd.Series, column_config: ColumnConfig, metadata: Metadata
 ) -> str | int:
+    value = row[column_config.id]
+
+    if pd.isna(value):
+        return ""
+
     try:
-        return int(float(row[column_config.id]))
+        return int(float(value))
     except ValueError:
-        return row[column_config.id]
+        return value
 
 
 def add_school_year(

--- a/liiatools/tests/common/test_transform_functions.py
+++ b/liiatools/tests/common/test_transform_functions.py
@@ -1,0 +1,36 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+from liiatools.common.data import ColumnConfig
+from liiatools.common._transform_functions import to_integer
+
+class TestToInteger(unittest.TestCase):
+    def setUp(self):
+        self.column_config = ColumnConfig(id="test_column", type="integer")
+        self.metadata = {"metadata": "test"}
+
+    def test_to_integer_with_valid_number(self):
+        row = pd.Series({"test_column": "123.0"})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, 123)
+
+    def test_to_integer_with_invalid_number(self):
+        row = pd.Series({"test_column": "abc"})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, "abc")
+
+    def test_to_integer_with_nan(self):
+        row = pd.Series({"test_column": np.nan})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, "")
+
+    def test_to_integer_with_na(self):
+        row = pd.Series({"test_column": pd.NA})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, "")
+
+    def test_to_integer_with_empty_value(self):
+        row = pd.Series({"test_column": None})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, "")


### PR DESCRIPTION
to_integer function was causing TransformErrors when pd.NA was a value in the cell. This now captures that, along with other types of blanks such as np.nan and None and turns these into empty strings. Empty strings means we have consistent data for all blank values before hashing, so hashed outputs for blank values will be consistent making it easier to debug.

We have kept a return value in case of ValueError to allow for UPNs that also contain alphabet character to remain