### PR TITLE
sort from latest to earliest and keep first

### DIFF
--- a/liiatools/common/archive.py
+++ b/liiatools/common/archive.py
@@ -196,12 +196,12 @@ class DataframeArchive:
 
                 df = data[table_spec.id]
                 if sort_keys:
-                    df = df.sort_values(by=sort_keys, ascending=True)
+                    df = df.sort_values(by=sort_keys, ascending=False)
 
                 subset = [c.id for c in table_spec.columns if c.unique_key]
                 duplicate_mask = df.duplicated(
                     subset=subset if subset else None,
-                    keep="last",
+                    keep="first",
                 )
 
                 duplicate_rows = df.index[duplicate_mask].tolist()


### PR DESCRIPTION
Now during the concat job after concatenating the years of files together we sort from latest to earliest and keep first. We have done this because blank dates are always put to the bottom of a dataframe, we want to these to be considered the earliest rows of data so sorting from latest to earliest achieves this. Then of course we keep first as this is the latest data 