### PR TITLE
Config sensor switch

### DIFF
--- a/liiatools/common/data/__config.py
+++ b/liiatools/common/data/__config.py
@@ -42,6 +42,7 @@ class TableConfig(BaseModel):
 class PipelineConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    sensor_trigger: Dict
     retention_columns: Dict
     retention_period: Dict
     la_signed: Dict

--- a/liiatools/common/pipeline.py
+++ b/liiatools/common/pipeline.py
@@ -130,7 +130,7 @@ def move_files_for_sharing(
                     dest_path = file_path.split("/")[-1]
                     copy_file(source_fs, file_path, destination_fs, dest_path)
                 else:
-                    table_id = re.search(r"_([a-zA-Z0-9]*)\.", file_path)
+                    table_id = re.search(r"\d{4}_(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)*_*([a-zA-Z0-9_]*)\.", file_path)
                     if table_id and table_id.group(1) in required_table_id:
                         dest_path = file_path.split("/")[-1]
                         copy_file(source_fs, file_path, destination_fs, dest_path)

--- a/liiatools/common/pipeline.py
+++ b/liiatools/common/pipeline.py
@@ -130,8 +130,8 @@ def move_files_for_sharing(
                     dest_path = file_path.split("/")[-1]
                     copy_file(source_fs, file_path, destination_fs, dest_path)
                 else:
-                    table_id = re.search(r"\d{4}_(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)*_*([a-zA-Z0-9_]*)\.", file_path)
-                    if table_id and table_id.group(2) in required_table_id:
+                    table_id = re.search(r"(([a-zA-Z0-9]*)_([a-zA-Z0-9]*))\.", file_path)
+                    if table_id and table_id.group(3) in required_table_id or table_id and table_id.group(1) in required_table_id:
                         dest_path = file_path.split("/")[-1]
                         copy_file(source_fs, file_path, destination_fs, dest_path)
             except Exception as e:

--- a/liiatools/common/pipeline.py
+++ b/liiatools/common/pipeline.py
@@ -131,7 +131,7 @@ def move_files_for_sharing(
                     copy_file(source_fs, file_path, destination_fs, dest_path)
                 else:
                     table_id = re.search(r"\d{4}_(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)*_*([a-zA-Z0-9_]*)\.", file_path)
-                    if table_id and table_id.group(1) in required_table_id:
+                    if table_id and table_id.group(2) in required_table_id:
                         dest_path = file_path.split("/")[-1]
                         copy_file(source_fs, file_path, destination_fs, dest_path)
             except Exception as e:

--- a/liiatools/tests/common/test_archive.py
+++ b/liiatools/tests/common/test_archive.py
@@ -9,7 +9,7 @@ from liiatools.common.data import ColumnConfig, PipelineConfig, TableConfig
 @pytest.fixture
 def cfg():
     cfg = PipelineConfig(
-        remove_rows={"remove_rows": False},
+        sensor_trigger  ={"move_current_org_sensor": True},
         retention_columns={"year_column": "Year", "la_column": "LA"},
         retention_period={"PAN": 12, "SUFFICIENCY": 7},
         la_signed={

--- a/liiatools_pipeline/ops/common_org.py
+++ b/liiatools_pipeline/ops/common_org.py
@@ -30,7 +30,7 @@ def move_error_report():
 
 
 @op()
-def move_current_view_org():
+def move_current_view_org(config: CleanConfig):
     current_folder = opendir_location(incoming_folder(), "current")
     if current_folder is not None:
         destination_folder = shared_folder()
@@ -38,13 +38,16 @@ def move_current_view_org():
         existing_files = destination_folder.listdir("/")
 
         authority_regex = "|".join(authorities.codes)
-        current_files_regex = f"({authority_regex})_\d{{4}}"
+        file_name_list = [table.id for table in pipeline_config(config).table_list]
+        file_regex = "|".join(file_name_list)
+
+        current_files_regex = f"({authority_regex})_\d{{4}}_({file_regex})"
         pl.remove_files(current_files_regex, existing_files, destination_folder)
 
         log.info("Moving current files to destination...")
-        pl.move_files_for_sharing(current_folder, destination_folder)
+        pl.move_files_for_sharing(current_folder, destination_folder, required_table_id=file_name_list)
     else:
-        log.error("No current files found")
+        log.error(f"No current files found fpr {config.dataset}")
 
 
 @op()

--- a/liiatools_pipeline/sensors/job_success_sensor.py
+++ b/liiatools_pipeline/sensors/job_success_sensor.py
@@ -8,6 +8,7 @@ from dagster import (
 )
 from decouple import config as env_config
 
+from liiatools_pipeline.assets.common import pipeline_config
 from liiatools_pipeline.jobs.annex_a_org import deduplicate_annex_a
 from liiatools_pipeline.jobs.common_la import clean, concatenate, move_current_la
 from liiatools_pipeline.jobs.common_org import (
@@ -165,10 +166,14 @@ def move_error_reports_sensor(context):
     minimum_interval_seconds=int(env_config("SENSOR_MIN_INTERVAL")),
 )
 def move_current_org_sensor(context):
+    allowed_datasets = env_config("ALLOWED_DATASETS").split(",")
+    context.log.info(f"Move concat allowed datasets: {allowed_datasets}")
+
     run_records = context.instance.get_run_records(
         filters=RunsFilter(
             job_name=reports.name,
             statuses=[DagsterRunStatus.SUCCESS],
+            tags={"dataset": allowed_datasets},
         ),
         order_by="update_timestamp",
         ascending=False,
@@ -176,13 +181,35 @@ def move_current_org_sensor(context):
     )
 
     if run_records:  # Ensure there is at least one run record
-        context.log.info(f"Run records found for reports job")
-        latest_run_record = run_records[0]
-        context.log.info(f"Run key: {latest_run_record.dagster_run.run_id}")
+        context.log.info(f"Run records found for reports job in move current org sensor")
+        for dataset in allowed_datasets:
+            clean_config = CleanConfig(
+                dataset_folder=None,
+                la_folder=None,
+                input_la_code=None,
+                dataset=dataset,
+            )
+            sensor_trigger = pipeline_config(clean_config).sensor_trigger["move_current_org_sensor"]
+            if sensor_trigger:
+                context.log.info(f"Sensor trigger is enabled for {dataset}")
+                latest_run_id = find_previous_matching_dataset_run(
+                    run_records,
+                    dataset,
+                )  # Get the most recent dataset run id
+                context.log.info(f"Run key: {latest_run_id}, dataset: {dataset}")
 
-        yield RunRequest(
-            run_key=latest_run_record.dagster_run.run_id,
-        )
+                yield RunRequest(
+                    run_key=latest_run_id,
+                    run_config=RunConfig(
+                        ops={
+                            "move_current_view_org": clean_config,
+                        }
+                    ),
+                )
+            else:
+                context.log.info(
+                    f"Sensor trigger is disabled for {dataset}, skipping move_current_org"
+                )
 
 
 @sensor(
@@ -207,32 +234,34 @@ def move_concat_sensor(context):
     )
 
     if run_records:  # Ensure there is at least one run record
-        if "annex_a" in allowed_datasets:
-            allowed_datasets.remove("annex_a")
-            context.log.info(f"Annex A removed from reports job for move concat sensor")
-        # Check if there are run records for the reports job after removing annex_a
-        if run_records:
-            context.log.info(f"Run records found for reports job in move concat sensor")
+        context.log.info(f"Run records found for reports job in move concat sensor")
         for dataset in allowed_datasets:
-            latest_run_id = find_previous_matching_dataset_run(
-                run_records,
-                dataset,
-            )  # Get the most recent dataset run id
-            context.log.info(f"Run key: {latest_run_id}, dataset: {dataset}")
             clean_config = CleanConfig(
                 dataset_folder=None,
                 la_folder=None,
                 input_la_code=None,
                 dataset=dataset,
             )
-            yield RunRequest(
-                run_key=latest_run_id,
-                run_config=RunConfig(
-                    ops={
-                        "move_concat_view": clean_config,
-                    }
-                ),
-            )
+            sensor_trigger = pipeline_config(clean_config).sensor_trigger["move_concat_sensor"]
+            if sensor_trigger:
+                context.log.info(f"Sensor trigger is enabled for {dataset}")
+                latest_run_id = find_previous_matching_dataset_run(
+                    run_records,
+                    dataset,
+                )  # Get the most recent dataset run id
+                context.log.info(f"Run key: {latest_run_id}, dataset: {dataset}")
+                yield RunRequest(
+                    run_key=latest_run_id,
+                    run_config=RunConfig(
+                        ops={
+                            "move_concat_view": clean_config,
+                        }
+                    ),
+                )
+            else:
+                context.log.info(
+                    f"Sensor trigger is disabled for {dataset}, skipping move_concat"
+                )
 
 
 @sensor(

--- a/poetry.lock
+++ b/poetry.lock
@@ -2059,7 +2059,7 @@ develop = false
 type = "git"
 url = "https://github.com/SocialFinanceDigitalLabs/liia-tools-pipeline-config.git"
 reference = "HEAD"
-resolved_reference = "0b8d057e4c5417a6ec5bc6f5031969d6439d772c"
+resolved_reference = "da77d79b452b86cd7b4b1e015a103f18c44d5902"
 
 [[package]]
 name = "lxml"
@@ -3121,7 +3121,6 @@ files = [
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bb89f0a835bcfc1d42ccd5f41f04870c1b936d8507c6df12b7737febc40f0909"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f0c2d907a1e102526dd2986df638343388b94c33860ff3bbe1384130828714b1"},
     {file = "psycopg2_binary-2.9.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f8157bed2f51db683f31306aa497311b560f2265998122abe1dce6428bd86567"},
-    {file = "psycopg2_binary-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:27422aa5f11fbcd9b18da48373eb67081243662f9b46e6fd07c3eb46e4535142"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-macosx_12_0_x86_64.whl", hash = "sha256:eb09aa7f9cecb45027683bb55aebaaf45a0df8bf6de68801a6afdc7947bb09d4"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b73d6d7f0ccdad7bc43e6d34273f70d587ef62f824d7261c4ae9b8b1b6af90e8"},
     {file = "psycopg2_binary-2.9.10-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce5ab4bf46a211a8e924d307c1b1fcda82368586a19d0a24f8ae166f5c784864"},


### PR DESCRIPTION
Will now use the config files to determine whether to trigger a run for a given sensor, specifically the move_current_org_sensor and move_concat_sensor. In order for this to work I've had to adjust the move_current_org job so that it works per dataset. This means move_current_org will now look for specific current_dataset files in the shared_folder and remove those, before moving the new current_dataset files into the shared_folder. This means we will trigger more of these runs (where allowed) but they will be moving less data per run.

To test this before completing the liia-tools-pipeline-config PR you can type `poetry add git+https://github.com/SocialFinanceDigitalLabs/liia-tools-pipeline-config.git#b69d91b` and this will install the latest commit from that branch.