### PR TITLE
update header_regex in pnw_census

### DIFF
--- a/liiatools/pnw_census_pipeline/spec/pnw_census_schema.yml
+++ b/liiatools/pnw_census_pipeline/spec/pnw_census_schema.yml
@@ -10,6 +10,8 @@ column_map:
               - "1"
         canbeblank: false
       Placing Authority:
+        header_regex: 
+          - /.*placing authority.*/i
         category:
           - code: Bolton
           - code: Bury
@@ -23,6 +25,8 @@ column_map:
           - code: Wigan
         canbeblank: False
       Identifier:
+        header_regex: 
+            - /.*identifier.*/i
         string: "alphanumeric"
         canbeblank: False
       Age:
@@ -526,7 +530,7 @@ column_map:
           - code: Not applicable
         canbeblank: True
         header_regex:
-          - /.*primary placing at a distance reason.*/i
+          - /.*primary placing at distance reason.*/i
       Type of provision:
         category:
           - code: "Fostering - Independent Foster Care (IFA)"
@@ -606,7 +610,7 @@ column_map:
           decimal_places: 2
         canbeblank: False
         header_regex:
-          - /.*social care.*/i
+          - /contribution.*social care.*/i
       Contribution from Education:
         numeric:
           type: "float"


### PR DESCRIPTION
Update header_regex in pnw_census to avoid duplicate matching and make sure we match previously unmatched columns. Used the pnw_census_2019_FAKE.csv headers sent over as a template for matching