### PR TITLE
utf8 encoding handles BOM

### DIFF
--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -52,7 +52,7 @@ def tablib_parse(source: FileLocator):
         data = f.read()
 
     try:
-        data = data.decode("utf-8")
+        data = data.decode("utf-8-sig")
         data = StringIO(data)
     except UnicodeDecodeError:
         data = BytesIO(data)


### PR DESCRIPTION
Found that UTF8 files with a BOM meant that the first cell was not being read in correctly, meaning commas in this cell were being interpreted as a delimitator. 

The updated encoding makes sure the BOM (if present) is interpreted as metadata rather than part of the file contents. If file has no BOM there is no change.