### PR TITLE
Valueerror raised in error log

### DIFF
--- a/liiatools/common/spec/__data_schema.py
+++ b/liiatools/common/spec/__data_schema.py
@@ -181,7 +181,6 @@ class DataSchema(BaseModel):
                 if len(matching_configs) == 1:
                     matched_columns.append(matching_configs[0])
                 elif len(matching_configs) > 1:
-                    # this is were we need to raise an error
                     raise ValueError(
                         "The actual column name matched multiple configured columns"
                     )

--- a/liiatools/common/spec/__data_schema.py
+++ b/liiatools/common/spec/__data_schema.py
@@ -181,6 +181,7 @@ class DataSchema(BaseModel):
                 if len(matching_configs) == 1:
                     matched_columns.append(matching_configs[0])
                 elif len(matching_configs) > 1:
+                    # this is were we need to raise an error
                     raise ValueError(
                         "The actual column name matched multiple configured columns"
                     )

--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -192,7 +192,15 @@ def add_table_name(event, schema: DataSchema):
                 type="BlankHeaders",
                 message=f"Could not identify headers as first row is blank",
             )
-        table_name = schema.get_table_from_headers(event.headers)
+        try:
+            table_name = schema.get_table_from_headers(event.headers)
+        except ValueError as e:
+            if str(e) == "The actual column name matched multiple configured columns":
+                return EventErrors.add_to_event(
+                    event,
+                    type="HeaderError",
+                    message=f"Could not identify as a column name matched multiple columns in the configuration.",
+                )
 
     if table_name:
         return event.from_event(

--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -199,7 +199,7 @@ def add_table_name(event, schema: DataSchema):
                 return EventErrors.add_to_event(
                     event,
                     type="HeaderError",
-                    message=f"Could not identify as a column name matched multiple columns in the configuration.",
+                    message=f"Could not identify as a column name matched multiple columns in the configuration",
                 )
 
     if table_name:


### PR DESCRIPTION
Valueerror raised by a header matching multiple columns in the config is now outputs a helpful message to the error log and does not crash clean.

To test, I used a file with the full pnw headers and updated the Contribution from Social Care regex in the YML to:

```
        header_regex:
          - /.*social care.*/i
```