### PR TITLE
update dedup to allow asc and desc

### DIFF
--- a/liiatools/common/aggregate.py
+++ b/liiatools/common/aggregate.py
@@ -74,11 +74,13 @@ class DataframeAggregator:
         """
         for table_spec in self.config.table_list:
             if table_spec.id in data:
-                sort_keys = table_spec.sort_keys
+                sort_tuples = table_spec.sort_keys
 
                 df = data[table_spec.id]
-                if sort_keys:
-                    df = df.sort_values(by=sort_keys, ascending=True)
+                if sort_tuples:
+                    by = [col_id for col_id, _ in sort_tuples]
+                    asc = [asc for _, asc in sort_tuples]
+                    df = df.sort_values(by=by, ascending=asc)
                 df = df.drop_duplicates(
                     subset=[c.id for c in table_spec.columns if c.unique_key]
                     if [c.id for c in table_spec.columns if c.unique_key]

--- a/liiatools/common/archive.py
+++ b/liiatools/common/archive.py
@@ -192,11 +192,13 @@ class DataframeArchive:
 
         for table_spec in self.config.table_list:
             if table_spec.id in data:
-                sort_keys = table_spec.sort_keys
+                sort_tuples = table_spec.sort_keys
 
                 df = data[table_spec.id]
-                if sort_keys:
-                    df = df.sort_values(by=sort_keys, ascending=False)
+                if sort_tuples:
+                    by = [col_id for col_id, _ in sort_tuples]
+                    asc = [asc for _, asc in sort_tuples]
+                    df = df.sort_values(by=by, ascending=asc)
 
                 subset = [c.id for c in table_spec.columns if c.unique_key]
                 duplicate_mask = df.duplicated(

--- a/liiatools/common/data/__config.py
+++ b/liiatools/common/data/__config.py
@@ -37,7 +37,6 @@ class TableConfig(BaseModel):
             for c in self.columns
             if c.sort is not None
         ]
-        # sort_keys = [(c.id, c.sort) for c in self.columns if c.sort is not None]
         sort_tuples.sort(key=lambda x: x[2])
         return [(col_id, asc) for col_id, asc, _ in sort_tuples]
 

--- a/liiatools/common/data/__config.py
+++ b/liiatools/common/data/__config.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from pydantic import BaseModel, ConfigDict
 
@@ -12,6 +12,7 @@ class ColumnConfig(BaseModel):
     enrich: str | list = None
     degrade: str = None
     sort: int = None
+    asc: bool = False
     exclude: List[str] = []
 
 
@@ -27,13 +28,18 @@ class TableConfig(BaseModel):
         return ix[value]
 
     @property
-    def sort_keys(self) -> List[str]:
+    def sort_keys(self) -> List[Tuple[str, bool]]:
         """
-        Returns a list of column ids that should be used to sort the table in order of priority
+        Returns a list of (column id, ascending) tuples that should be used to sort the table in order of priority
         """
-        sort_keys = [(c.id, c.sort) for c in self.columns if c.sort is not None]
-        sort_keys.sort(key=lambda x: x[1])
-        return [c[0] for c in sort_keys]
+        sort_tuples = [
+            (c.id, c.asc, c.sort)
+            for c in self.columns
+            if c.sort is not None
+        ]
+        # sort_keys = [(c.id, c.sort) for c in self.columns if c.sort is not None]
+        sort_tuples.sort(key=lambda x: x[2])
+        return [(col_id, asc) for col_id, asc, _ in sort_tuples]
 
     def columns_for_profile(self, profile: str) -> List[ColumnConfig]:
         return [c for c in self.columns if profile not in c.exclude]


### PR DESCRIPTION
Currently it is hardcoded that when fields are used in deduplication, the sort must be descending. This has worked for the dates that we've used so far, though seems a little short-sighted in retrospect :D. This change adds a new column to the config file that can set the sort to ascending where required (as will be the case for the school census).

To test this with a config that has been set up to work with it, please set liia-tools-config-pipeline in the .toml file to look for the branch called "sort-more-flexible" and then run poetry update liia-tools-config-pipeline.

This config has the DOB in ssda903 Header set to be sorted after Year. It is set to sort ascending, so it will put duplicates with the oldest DOB first in the sort.

All other values are by default set to False, so you can test that this is working still by seeing if the standard dedup on applicable fields still works.