### PR TITLE
add xml_row to error log

### DIFF
--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -454,6 +454,7 @@ def collect_errors(stream):
                     "c_ix",
                     "table_name",
                     "header",
+                    "xml_row",
                 )
                 collected_errors.append(error_entry)
 

--- a/liiatools/common/stream_parse.py
+++ b/liiatools/common/stream_parse.py
@@ -36,7 +36,7 @@ def dom_parse(source, filename, **kwargs):
                 )
             elif action == "end":
                 if elem.text and elem.text.strip():
-                    yield TextNode(cell=elem.text, filename=filename, text=None)
+                    yield TextNode(cell=elem.text, filename=filename, text=None, xml_row=elem.sourceline)
 
                 yield EndElement(tag=elem.tag, node=elem, filename=filename)
                 if elem.tail:


### PR DESCRIPTION
Add xml_row to the error logs so when ConversionErrors pop up there is an accompanying row to identify where this happened in the input file