### PR TITLE
UASC Sex field to also accept 1 and 2 from 2025

### DIFF
--- a/liiatools/ssda903_pipeline/spec/SSDA903_schema_2025.diff.yml
+++ b/liiatools/ssda903_pipeline/spec/SSDA903_schema_2025.diff.yml
@@ -13,11 +13,13 @@ column_map.uasc.SEX.category:
   description: Updated SEX codes for 2025 schema
   value:
     - code: "M"
-      name: "Male"
-      name: "1"
+      name: 
+        - "Male"
+        - "1"
     - code: "F"
-      name: "Female"
-      name: "2"
+      name: 
+        - "Female"
+        - "2"
     - code: "U"
       name: "Unknown"
 column_map.episodes.PLACE.category:


### PR DESCRIPTION
Change to reflect the fact that DfE have returned a combination of old and new values in the 2025 submission

According to my understanding of how this works, this should also accept 'Female', but in my test doesn't (didn't test Male) however, unsure if this is a barrier to merging or not?