### PR TITLE
new cin dedup job

### DIFF
--- a/liiatools/cin_census_pipeline/dedup_cin.py
+++ b/liiatools/cin_census_pipeline/dedup_cin.py
@@ -1,0 +1,17 @@
+import pandas as pd
+
+def dedup_cin(data: pd.DataFrame) -> pd.DataFrame:
+    """
+    Deduplicates CIN Census data at a CIN episode level
+    :param data: Concatenated CIN Census flatfile dataframe
+    :return: Deduplicated CIN Census dataframe
+    """
+    # Find the latest year for each set of child_id and CIN referral date sets
+    latest_years = (
+        data.groupby(["LAchildID", "CINreferralDate"])["Year"].transform("max")
+    )
+
+    # Filter to only include latest_years rows
+    deduplicated_data = data[data["Year"] == latest_years]
+
+    return deduplicated_data

--- a/liiatools/common/constants.py
+++ b/liiatools/common/constants.py
@@ -48,3 +48,8 @@ class SessionNamesCINReports(StrEnum):
     """Enum for CIN Reports session folders."""
 
     INCOMING_FOLDER = "incoming"
+
+class SessionNamesCINDedup(StrEnum):
+    """Enum for CIN Dedup session folders."""
+
+    INCOMING_FOLDER = "incoming"

--- a/liiatools/tests/cin_census/test_dedup_cin.py
+++ b/liiatools/tests/cin_census/test_dedup_cin.py
@@ -1,0 +1,46 @@
+import pandas as pd
+
+from liiatools.cin_census_pipeline.dedup_cin import dedup_cin
+
+
+def test_dedup_cin():
+    # Test dataframe
+    df = pd.DataFrame({
+        "LAchildID": ["A", "A", "A", "A", "B", "B", "C"],
+        "CINreferralDate": [
+            "2024-01-01", "2024-01-01", "2024-01-01",  # A same referral date
+            "2023-02-02",                              # A different referral date
+            "2023-05-05", "2023-05-05",                # B same referral date
+            "2022-09-09"                               # C unique
+        ],
+        "Year": [2023, 2023, 2024, 2023, 2022, 2023, 2022]
+    })
+
+    # Act
+    result = dedup_cin(df)
+
+    # --- Assertions ---
+    # A, referral 2024-01-01 → only latest year (2024) should remain
+    a_ref1 = result[(result["LAchildID"] == "A") & 
+                    (result["CINreferralDate"] == "2024-01-01")]
+    assert all(a_ref1["Year"] == 2024)
+    assert len(a_ref1) == 1  # should only keep the newest row(s)
+
+    # A, referral 2023-02-02 → no duplicates, should still be kept
+    a_ref2 = result[(result["LAchildID"] == "A") & 
+                    (result["CINreferralDate"] == "2023-02-02")]
+    assert len(a_ref2) == 1
+    assert a_ref2["Year"].iloc[0] == 2023
+
+    # B, referral 2023-05-05 → only latest year (2023) should remain
+    b_ref = result[(result["LAchildID"] == "B") & 
+                   (result["CINreferralDate"] == "2023-05-05")]
+    assert all(b_ref["Year"] == 2023)
+    assert len(b_ref) == 1
+
+    # C should still be present since it had no duplicates
+    assert "C" in result["LAchildID"].values
+
+    # Check overall row count: 
+    # A(1 row from 2024, 1 row from alt ref in 2023) + B(1) + C(1) = 4 rows
+    assert len(result) == 4

--- a/liiatools_pipeline/jobs/cin_la.py
+++ b/liiatools_pipeline/jobs/cin_la.py
@@ -1,0 +1,12 @@
+from dagster import get_dagster_logger, job
+
+from liiatools_pipeline.ops import cin_la as cin
+
+log = get_dagster_logger()
+
+
+@job
+def cin_deduplicate_files():
+    log.info("Deduplicating CIN files...")
+    session_folder = cin.create_cin_dedup_session_folder()
+    cin.cin_deduplication(session_folder)

--- a/liiatools_pipeline/ops/cin_la.py
+++ b/liiatools_pipeline/ops/cin_la.py
@@ -1,0 +1,59 @@
+import re
+
+import pandas as pd
+from dagster import In, Out, get_dagster_logger, op
+from fs.base import FS
+
+from liiatools.common import pipeline as pl
+from liiatools.common.constants import SessionNamesCINDedup
+from liiatools.common.data import DataContainer
+from liiatools.cin_census_pipeline.dedup_cin import dedup_cin
+from liiatools_pipeline.assets.common import shared_folder, workspace_folder
+
+log = get_dagster_logger()
+
+@op(
+    out={
+        "session_folder": Out(FS),
+    }
+)
+def create_cin_dedup_session_folder() -> FS:
+    session_folder, session_id = pl.create_session_folder(
+        workspace_folder(), SessionNamesCINDedup
+    )
+    session_folder = session_folder.opendir(SessionNamesCINDedup.INCOMING_FOLDER)
+
+    concat_folder = shared_folder().opendir("concatenated/cin")
+    pl.move_files_for_sharing(
+        concat_folder, session_folder
+    )
+
+    return session_folder
+
+@op(
+    ins={
+        "session_folder": In(FS),
+    },
+)
+def cin_deduplication(
+    session_folder: FS,
+):
+    log.info("Opening Concatenated folder for CIN...")
+    concat_folder = shared_folder().opendir("concatenated/cin")
+    files = session_folder.listdir("/")
+
+    for file in files:
+        log.info(f"Deduplicating for {file}")
+        data = DataContainer()
+        cin_table = re.search(r"cin", file)
+        la_code = re.search(r"([A-Za-z0-9]*)_", file)
+        print(la_code.group(1))
+        with session_folder.open(file, "r") as f:
+            try:
+                df = pd.read_csv(f)
+                df = dedup_cin(df)
+                data[cin_table.group(0)] = df
+            except TypeError as err:
+                log.error(f"Deduplicating {file} failed: {err}")
+        log.info(f"Exporting deduplicated data for {file}...")
+        data.export(concat_folder, f"{la_code.group(1)}_cin_", "csv")

--- a/liiatools_pipeline/ops/common_la.py
+++ b/liiatools_pipeline/ops/common_la.py
@@ -248,7 +248,8 @@ def process_files(
 
             log.info(f"Degraded file exported for {basename(file_locator.name)}")
 
-            error_report.extend(current.deduplicate(cleanfile_result.data).errors)
+            if config.dataset != "cin":
+                error_report.extend(current.deduplicate(cleanfile_result.data).errors)
 
             error_report.set_property("filename", file_locator.name)
             error_report.set_property("uuid", uuid)
@@ -301,7 +302,7 @@ def create_concatenated_view(current: DataframeArchive, config: CleanConfig):
         pl.remove_files(la_files_regex, existing_files, concat_folder)
         log.info(f"Successfully removed files")
 
-        if config.dataset == "annex_a":
+        if config.dataset in ("annex_a","cin"):
             concat_data = current.current(la_code, deduplicate_mode="N")
         else:
             concat_data = current.current(la_code)

--- a/liiatools_pipeline/repository_la.py
+++ b/liiatools_pipeline/repository_la.py
@@ -3,11 +3,13 @@ from dagster import repository
 from liiatools.common._fs_serializer import register
 from liiatools_pipeline.jobs.common_la import clean, concatenate, move_current_la
 from liiatools_pipeline.jobs.ssda903_la import ssda903_fix_episodes
+from liiatools_pipeline.jobs.cin_la import cin_deduplicate_files
 from liiatools_pipeline.sensors.config_schedule import pipeline_config_schedule
 from liiatools_pipeline.sensors.job_success_sensor import (
     concatenate_sensor,
     move_current_la_sensor,
     ssda903_fix_episodes_sensor,
+    cin_deduplicate_files_sensor,
 )
 from liiatools_pipeline.sensors.location_schedule import clean_schedule
 
@@ -27,6 +29,7 @@ def sync():
         move_current_la,
         concatenate,
         ssda903_fix_episodes,
+        cin_deduplicate_files,
     ]
     schedules = [
         clean_schedule,
@@ -36,6 +39,7 @@ def sync():
         move_current_la_sensor,
         concatenate_sensor,
         ssda903_fix_episodes_sensor,
+        cin_deduplicate_files_sensor,
     ]
 
     return jobs + schedules + sensors


### PR DESCRIPTION
This PR makes a wholesale change to the way CIN Census is deduplicated. It:
- [ ] stops cin from being deduplicated as normal in clean (as with Annex A)
- [ ] stops the error log from being updated with duplicates
- [ ] creates a new job that runs after concatenate for cin that:
- [ ] groups CIN episodes by CIN referral date and Child ID and works out the max year for these sets
- [ ] filters the dataset to only keep the max year

In effect this treats the deduplication at the CIN episode module level, ensuring that, unlike the current solution:
- [ ] duplicate rows within a CIN episode module e.g. if there were two reviews on the same day are not removed
- [ ] modules present in two consecutive returns, based on CIN referral date, will be fully deduped i.e. all rows relating to the older copy will be removed; currently if a row within a duplicate CIN episode module had a difference in date e.g. the assessment date changed from year to year, all but this row from the older copy would be removed, but this row would remain - this should not happen