### PR TITLE
remove whitespace and force upper case for child id

### DIFF
--- a/liiatools/common/_transform_functions.py
+++ b/liiatools/common/_transform_functions.py
@@ -65,7 +65,7 @@ def add_school_type(row: pd.Series, column_config: ColumnConfig, metadata: Metad
 def to_integer(
     row: pd.Series, column_config: ColumnConfig, metadata: Metadata
 ) -> str | int:
-    value = row[column_config.id]
+    value = row[column_config.id].strip() if isinstance(row[column_config.id], str) else row[column_config.id]
 
     if pd.isna(value):
         return ""
@@ -73,7 +73,7 @@ def to_integer(
     try:
         return int(float(value))
     except ValueError:
-        return value
+        return value.upper()
 
 
 def add_school_year(

--- a/liiatools/common/_transform_functions.py
+++ b/liiatools/common/_transform_functions.py
@@ -75,6 +75,8 @@ def to_integer(
     except ValueError:
         if isinstance(value, str):
             return value.upper()
+        else:
+            return value
 
 
 def add_school_year(

--- a/liiatools/common/_transform_functions.py
+++ b/liiatools/common/_transform_functions.py
@@ -73,7 +73,8 @@ def to_integer(
     try:
         return int(float(value))
     except ValueError:
-        return value.upper()
+        if isinstance(value, str):
+            return value.upper()
 
 
 def add_school_year(

--- a/liiatools/tests/common/test_transform_functions.py
+++ b/liiatools/tests/common/test_transform_functions.py
@@ -9,18 +9,23 @@ from liiatools.common.data import ColumnConfig
 
 class TestToInteger(unittest.TestCase):
     def setUp(self):
-        self.column_config = ColumnConfig(id="test_column", type="integer")
+        self.column_config = ColumnConfig(id="test_column", type="string")
         self.metadata = {"metadata": "test"}
 
     def test_to_integer_with_valid_number(self):
-        row = pd.Series({"test_column": "123.0"})
+        row = pd.Series({"test_column": " 123.0"})
         result = to_integer(row, self.column_config, self.metadata)
         self.assertEqual(result, 123)
 
-    def test_to_integer_with_invalid_number(self):
-        row = pd.Series({"test_column": "abc"})
+    def test_to_integer_with_valid_int(self):
+        row = pd.Series({"test_column": 123})
         result = to_integer(row, self.column_config, self.metadata)
-        self.assertEqual(result, "abc")
+        self.assertEqual(result, 123)
+
+    def test_to_integer_with_valid_string(self):
+        row = pd.Series({"test_column": " abc123"})
+        result = to_integer(row, self.column_config, self.metadata)
+        self.assertEqual(result, "ABC123")
 
     def test_to_integer_with_nan(self):
         row = pd.Series({"test_column": np.nan})


### PR DESCRIPTION
Remove the trailing and leading whitespace, as well as force upper case for the to_integer function which acts on all identifier columns in the pipelines