### PR TITLE
change from lad25cd to ctyua25cd

### DIFF
--- a/liiatools/common/_transform_functions.py
+++ b/liiatools/common/_transform_functions.py
@@ -101,7 +101,7 @@ def add_la_from_postcode(data: pd.DataFrame, mapping_field: str, output_field: s
 
     # Merge LA name into data
     merged = data.merge(mapping_df, left_on=mapping_field, right_on="pcds", how="left")
-    data[output_field] = merged["lad25cd"]
+    data[output_field] = merged["CTYUA25CD"]
     return data
 
 

--- a/liiatools_pipeline/ops/school_census_org.py
+++ b/liiatools_pipeline/ops/school_census_org.py
@@ -115,7 +115,7 @@ def school_census_cross_outputs(
     # Check for GIAS lookup file
     ext_folder = external_data_folder()
     try:
-        GIAS_lookup = open_file(ext_folder, "gias_lad25cd_lookup.csv")
+        GIAS_lookup = open_file(ext_folder, "gias_ctyua25cd_lookup.csv")
     except errors.ResourceNotFound as err:
         log.error(f"No GIAS lookup file to open: {err}")
         log.info("Exiting run as external dataset resources not available")
@@ -139,9 +139,9 @@ def school_census_cross_outputs(
 
     # Join GIAS code to addresses
     addresses = addresses.merge(
-        right=GIAS_lookup[["GIAS code", "lad25cd"]],
+        right=GIAS_lookup[["GIAS code", "ctyua25cd"]],
         left_on="child_home_la",
-        right_on="lad25cd",
+        right_on="ctyua25cd",
     )
     addresses = addresses.rename(columns={"GIAS code": "child_home_GIAS"})
 

--- a/liiatools_pipeline/ops/school_census_org.py
+++ b/liiatools_pipeline/ops/school_census_org.py
@@ -144,6 +144,7 @@ def school_census_cross_outputs(
         right_on="ctyua25cd",
     )
     addresses = addresses.rename(columns={"GIAS code": "child_home_GIAS"})
+    addresses = addresses.drop("ctyua25cd", axis=1)
 
     # Open fsm files, where there may be one or two files to open
     fsm_pattern = re.compile(r"school_census_fsmperiod\.csv$")


### PR DESCRIPTION
The change here is to use CTYUA25CD instead of LAD25CD to provide upper-tier rather than lower-tier authority codes in postcode joins.

To run this, you will need these updated files, which go in the external directory:
- new copy of postcode_la_lookup (will be emailed, as parquet)
- updated gias lookup (attached)
[gias_ctyua25cd_lookup.csv](https://github.com/user-attachments/files/26940133/gias_ctyua25cd_lookup.csv)
