### PR TITLE
add manual trigger tag to stop clean_schedule reruns

### DIFF
--- a/liiatools_pipeline/sensors/job_success_sensor.py
+++ b/liiatools_pipeline/sensors/job_success_sensor.py
@@ -483,7 +483,7 @@ def full_clean_sensor(context):
 
         yield RunRequest(
             run_key=f"{latest_run_id}{la}",
-            tags={"dataset": dataset},
+            tags={"dataset": dataset, "manual_trigger": "true"},
             run_config=RunConfig(
                 ops={
                     "create_session_folder": clean_config,

--- a/liiatools_pipeline/sensors/location_schedule.py
+++ b/liiatools_pipeline/sensors/location_schedule.py
@@ -168,8 +168,12 @@ def clean_schedule(context):
                 limit=1000,
             )
 
+            run_records_without_manual_trigger = [
+                run for run in run_records if run.dagster_run.tags.get("manual_trigger") != "true"
+            ]
+
             previous_matching_run_id = find_previous_matching_run(
-                run_records,
+                run_records_without_manual_trigger,
                 run_key,
                 la_path,
                 dataset,


### PR DESCRIPTION
Have introduced a tag when triggering a manual run. This stops clean_schedule from picking up the change in runs and running when there are no actual change in the files (just a forced run on existing files)