### PR TITLE
add time to schema type and converters

### DIFF
--- a/liiatools/common/converters.py
+++ b/liiatools/common/converters.py
@@ -192,6 +192,25 @@ def to_date(value, dateformat="%d/%m/%Y"):
 
 
 @allow_blank
+def to_time(value, timeformat="%H:%M"):
+    """
+    Convert a string to a time based on the timeformat %H:%M and convert a datetime to this time format
+    :param value: A value to test and make sure it's a datetime or string object
+    :param timeformat: A format for the time to be read correctly, default to %H:%M
+    :return: Either the specified time, converted to a string in the correct format, or an empty string
+    """
+    try:
+        if isinstance(value, datetime):
+            return datetime.strftime(value, timeformat)
+        elif isinstance(value, str):
+            return datetime.strftime(datetime.strptime(value, timeformat), timeformat)
+        else:
+            raise ValueError(f"Invalid time: {value}")
+    except Exception as e:
+        raise ValueError(f"Invalid time: {value}") from e
+
+
+@allow_blank
 def to_nth_of_month(value: date, n: int = 1):
     """
     Converts dates to the nth day of the month. n defaults to first of the month

--- a/liiatools/common/spec/__data_schema.py
+++ b/liiatools/common/spec/__data_schema.py
@@ -77,6 +77,7 @@ class Column(BaseModel):
     string: Literal["alphanumeric", "postcode", "regex"] | None = None
     numeric: Numeric | None = None
     date: str | None = None
+    time: str | None = None
 
     dictionary: Dict | None = None
     category: List[Category] | None = None
@@ -98,6 +99,8 @@ class Column(BaseModel):
             return "numeric"
         elif self.date:
             return "date"
+        elif self.time:
+            return "time"
         elif self.category:
             return "category"
         else:

--- a/liiatools/common/stream_filters.py
+++ b/liiatools/common/stream_filters.py
@@ -21,6 +21,7 @@ from tablib import UnsupportedFormat, import_book, import_set
 from liiatools.common.converters import (
     to_category,
     to_date,
+    to_time,
     to_numeric,
     to_postcode,
     to_regex,
@@ -339,6 +340,8 @@ def conform_cell_types(event, preserve_value=False):
         converter = lambda x: to_category(x, column_spec)
     elif column_spec.type == "date":
         converter = lambda x: to_date(x, column_spec.date)
+    elif column_spec.type == "time":
+        converter = lambda x: to_time(x, column_spec.time)
     elif column_spec.type == "numeric":
         converter = lambda x: to_numeric(
             x,

--- a/liiatools/school_census_pipeline/spec/school_census_schema_2016.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2016.diff.yml
@@ -802,7 +802,7 @@ spring:
             *alphanumeric-not-blank
         openingtime:
             &time
-            time: "%Y-%b-%d %H:%M:%S"
+            time: "%H:%M"
             canbeblank: yes
         closingtime:
             *time

--- a/liiatools/tests/common/test_converters.py
+++ b/liiatools/tests/common/test_converters.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 import pytest
 
@@ -6,6 +6,7 @@ from liiatools.common.converters import (
     allow_blank,
     to_category,
     to_date,
+    to_time,
     to_nth_of_month,
     to_numeric,
     to_postcode,
@@ -167,13 +168,46 @@ def test_to_numeric():
 
 def test_to_date():
     assert (
-        to_date(datetime.datetime(2020, 3, 19)) == datetime.datetime(2020, 3, 19).date()
+        to_date(datetime(2020, 3, 19)) == datetime(2020, 3, 19).date()
     )
-    assert to_date("15/03/2017") == datetime.datetime(2017, 3, 15).date()
+    assert to_date("15/03/2017") == datetime(2017, 3, 15).date()
+
+
+def test_to_time():
+    # Basic valid time strings - should return normalised string
+    assert to_time("14:30") == "14:30"
+    assert to_time("00:00") == "00:00"
+    assert to_time("23:59") == "23:59"
+
+    # Blank/None passthrough (allow_blank behaviour)
+    assert to_time("") == ""
+    assert to_time(None) == ""
+
+    # datetime input - should extract and return formatted time string
+    assert to_time(datetime(2024, 1, 15, 14, 30, 0)) == "14:30"
+    assert to_time(datetime(2024, 6, 1, 0, 0, 0)) == "00:00"
+    assert to_time(datetime(2024, 12, 31, 23, 59, 0)) == "23:59"
+
+    # Custom timeformat
+    assert to_time("14:30:00", timeformat="%H:%M:%S") == "14:30:00"
+    assert to_time(datetime(2024, 1, 15, 14, 30, 45), timeformat="%H:%M:%S") == "14:30:45"
+
+    with pytest.raises(ValueError):
+        to_time("99:99")
+    with pytest.raises(ValueError):
+        to_time("25:00")
+    with pytest.raises(ValueError):
+        to_time("12:60")
+    with pytest.raises(ValueError):
+        to_time("14:30:00")    # seconds not expected in default format
+    with pytest.raises(ValueError):
+        to_time("not a time")
+    with pytest.raises(ValueError):
+        to_time(12345)         # wrong type - neither datetime nor str
 
 
 def test_to_nth_of_month():
-    assert to_nth_of_month(datetime.datetime(2020, 5, 17)) == datetime.datetime(
+    assert to_nth_of_month(datetime(2020, 5, 17)) == datetime(
         2020, 5, 1
     )
 


### PR DESCRIPTION
Adds a 'time' type to the acceptable formats in the yaml schemas. Also adds the relevant sections to:
- streamfilters
- converters
- test_converters

datetime and strings that can be converted to HH:MM format are allowed, anything else raises a ValueError