### PR TITLE
School Census 2026 schema changes

### DIFF
--- a/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
@@ -1,4 +1,37 @@
 autumn:
+  column_map.learnerfamoffroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2025 return
+    value:
+      &learner-fam-type
+      category:
+        - code: "NLM"
+        - code: "EMH"
+        - code: "MMH"
+      canbeblank: yes
+  column_map.learnerfamonroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2025 return
+    value:
+      *learner-fam-type
+  column_map.learnerfamoffroll.learnerfamcode:
+    type: modify
+    description: Update codes for 2025 schema
+    value:
+      &learner-fam-code
+      category:
+      - code: "01"
+      - code: "02"
+      - code: "03"
+      - code: "04"
+      - code: "05"      
+      - code: "22"
+      canbeblank: yes
+  column_map.learnerfamonroll.learnerfamcode:
+    type: modify
+    description: Update codes for 2025 schema
+    value:
+      *learner-fam-code
   column_map.pupilnolongeronroll:
     type: remove
     description: Remove column from pupilnolongeronroll

--- a/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
@@ -52,6 +52,26 @@ autumn:
       - summerhalfterm2sessionsunauthorised
       - summerhalfterm2sessionseducational
       - summerhalfterm2sessionsexceptional
+  column_map.learningaimsoffroll:
+    type: remove
+    description: Remove column from learningaimsoffroll
+    value:
+      - traineeship
+  column_map.learningaimsonroll:
+    type: remove
+    description: Remove column from learningaimsonroll
+    value:
+      - traineeship
+  column_map.programmeaimsoffroll:
+    type: remove
+    description: Remove column from programmeaimsoffroll
+    value:
+      - traineeship
+  column_map.programmeaimsonroll:
+    type: remove
+    description: Remove column from programmeaimsonroll
+    value:
+      - traineeship
 
 spring:
   column_map.childcare.childcareplacesavailability:

--- a/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2025.diff.yml
@@ -18,7 +18,7 @@ autumn:
     type: modify
     description: Update codes for 2025 schema
     value:
-      &learner-fam-code
+      &learner-fam-code-aut
       category:
       - code: "01"
       - code: "02"
@@ -31,7 +31,7 @@ autumn:
     type: modify
     description: Update codes for 2025 schema
     value:
-      *learner-fam-code
+      *learner-fam-code-aut
   column_map.pupilnolongeronroll:
     type: remove
     description: Remove column from pupilnolongeronroll

--- a/liiatools/school_census_pipeline/spec/school_census_schema_2026.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2026.diff.yml
@@ -1,0 +1,28 @@
+spring:
+  column_map.learnerfamoffroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      &learner-fam-type
+      category:
+        - code: "NLM"
+        - code: "EMH"
+        - code: "MMH"
+      canbeblank: yes
+  column_map.learnerfamonroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      *learner-fam-type
+
+summer:
+  column_map.learnerfamoffroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      *learner-fam-type
+  column_map.learnerfamonroll.learnerfamtype:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      *learner-fam-type

--- a/liiatools/school_census_pipeline/spec/school_census_schema_2026.diff.yml
+++ b/liiatools/school_census_pipeline/spec/school_census_schema_2026.diff.yml
@@ -14,6 +14,19 @@ spring:
     description: Update codes for 2026 return
     value:
       *learner-fam-type
+  column_map.learnerfamoffroll.learnerfamcode:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      &learner-fam-code
+      category:
+      - code: "01"
+      - code: "02"
+      - code: "03"
+      - code: "04"
+      - code: "05"      
+      - code: "22"
+      canbeblank: yes
 
 summer:
   column_map.learnerfamoffroll.learnerfamtype:
@@ -26,3 +39,8 @@ summer:
     description: Update codes for 2026 return
     value:
       *learner-fam-type
+  column_map.learnerfamoffroll.learnerfamcode:
+    type: modify
+    description: Update codes for 2026 return
+    value:
+      *learner-fam-code


### PR DESCRIPTION
This PR updates the School Census pipeline to reflect changes made for the 2025-2026 returns. Please reference the attached files to compare against schema.

The changes do not impact any existing data flows, as the tables referenced are not used by any regions currently.
[School_census_annexes_v1.1.xlsx](https://github.com/user-attachments/files/28591769/School_census_annexes_v1.1.xlsx)
[CBDS_VersionMay2026.xlsx](https://github.com/user-attachments/files/28591771/CBDS_VersionMay2026.xlsx)
[School_census_2025_to_2026_business_and_technical_specification_version_1.5.pdf](https://github.com/user-attachments/files/28591773/School_census_2025_to_2026_business_and_technical_specification_version_1.5.pdf)
